### PR TITLE
Adding extension folder to package

### DIFF
--- a/ios/flutter_smartcar_auth.podspec
+++ b/ios/flutter_smartcar_auth.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.license          = { :file => '../LICENSE' }
   s.author           = { 'Smartcar' => 'support@smartcar.com' }
   s.source           = { :path => '.' }
-  s.source_files = 'Classes/**/*'
+  s.source_files = 'Classes/**/*', 'Extensions/**/*'
   s.dependency 'Flutter'
   s.dependency 'SmartcarAuth', '6.0.2'
   s.platform = :ios, '13.0'


### PR DESCRIPTION
Trying to run on iOS it was returning this error: Value of type 'AuthorizationError.ErrorType' has no member 'stringValue'. That was because the extension folder was not added to the .podspec
